### PR TITLE
Update packages: grunt, grunt-contrib-jshint, moca

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "hash"
   ],
   "devDependencies": {
-    "grunt": "0.4.5",
-    "grunt-contrib-jshint": "~0.2.0",
+    "grunt": "^1.0.3",
+    "grunt-contrib-jshint": "2.0.0",
     "grunt-mocha-test": "^0.12.7",
     "grunt-browserify": "^5.0.0",
-    "mocha": "^2.4.5",
+    "mocha": "5.2.0",
     "expect.js": "^0.3.1"
   },
   "scripts": {


### PR DESCRIPTION
This currently fails to install as a third-party package because running the **postinstall** script produces the following error when `grunt` is not installed globally:
```
sh: grunt: command not found
```
I've updated to the latest version of grunt to fix this. 

I've also updated to the latest versions of `grunt-contrib-jshint` and `moca` to address security vulnerabilities.

```
found 14 vulnerabilities (7 low, 6 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```